### PR TITLE
Use `testlofi` instead `lofi-player` to bundle through Parcel

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "dev": "parcel public/index.html --out-dir development -p 3000",
-    "pre-deploy": "yarn install && parcel build public/index.html --out-dir dist --public-url /lofi-player && workbox generateSW"
+    "pre-deploy": "yarn install && parcel build public/index.html --out-dir dist --public-url /testlofi && workbox generateSW"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Since your repository is contained inside `testlofi` path update it when building the public URL of the static files!