### PR TITLE
Use root path to deploy to Vercel and Netlify

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "scripts": {
     "dev": "parcel public/index.html --out-dir development -p 3000",
-    "pre-deploy": "yarn install && parcel build public/index.html --out-dir dist --public-url /testlofi && workbox generateSW"
+    "pre-deploy": "yarn install && parcel build public/index.html --out-dir dist --public-url / && workbox generateSW"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Try it.

Since Vercel and Netlify uploads our projects to the root path, we need to build the project targeting the root path, not a subpath like we have in GitHub pages.

Hope it can help!